### PR TITLE
openFileのファイルの存在と読み取り許可の確認処理を追加

### DIFF
--- a/http/GetRequest.cpp
+++ b/http/GetRequest.cpp
@@ -1,26 +1,36 @@
 #include "GetRequest.hpp"
 
-GetRequest::GetRequest(){}
+GetRequest::GetRequest() {}
 
-GetRequest::~GetRequest(){}
+GetRequest::~GetRequest() {}
 
-bool isCgiScript(const std::string& filePath) 
+bool isCgiScript(const std::string &filePath)
 {
     return filePath.size() >= 4 && filePath.substr(filePath.size() - 3) == ".sh";
 }
 
-std::string GetRequest::openFile(const std::string& filePath)
+std::string GetRequest::openFile(const std::string &filePath)
 {
-    std::cout << "In GetRequest::openFile   file psth = " << filePath << std::endl;    
-    std::ifstream file(filePath);
-    std::string content;
-    std::string line;
+    std::cout << "In GetRequest::openFile   file psth = " << filePath << std::endl;
 
-    if (file.is_open()) 
+    // ファイルの存在と読み取り許可を確認
+    struct stat buffer;
+    if (stat(filePath.c_str(), &buffer) != 0)
+        return "404 Not Found";
+
+    // 読み取り可能か確認
+    if ((buffer.st_mode & S_IRUSR) == 0)
+        return "403 Forbidden";
+
+    // ファイルを開いて内容を読み込む
+    std::ifstream file(filePath);
+    std::string content, line;
+
+    if (file.is_open())
     {
         content = "200 OK";
         file.close();
-    } 
+    }
     else
     {
         content = "404 Not Found";
@@ -30,7 +40,7 @@ std::string GetRequest::openFile(const std::string& filePath)
     return content;
 }
 
-std::string GetRequest::getBody(const std::string& status, const std::string& filePath)
+std::string GetRequest::getBody(const std::string &status, const std::string &filePath)
 {
     std::string body;
     if (status == "200 OK")
@@ -50,10 +60,10 @@ std::string GetRequest::getBody(const std::string& status, const std::string& fi
     return body;
 }
 
-void GetRequest::executeCgiScript(Request& req, Response& res)
+void GetRequest::executeCgiScript(Request &req, Response &res)
 {
     std::string path = req.getUri();
-    if (access(path.c_str(), F_OK | X_OK) != 0) 
+    if (access(path.c_str(), F_OK | X_OK) != 0)
     {
         res.setStatus("404 Not Found");
         res.setBody("<html><body><h1>404 Not Found</h1><p>Requested script not found.</p></body></html>");
@@ -62,23 +72,24 @@ void GetRequest::executeCgiScript(Request& req, Response& res)
     int pipefd[2];
     pipe(pipefd);
     pid_t pid = fork();
-    if (pid == 0) //child
+    if (pid == 0) // child
     {
         close(pipefd[0]);
-        dup2(pipefd[1], STDOUT_FILENO); 
+        dup2(pipefd[1], STDOUT_FILENO);
         dup2(pipefd[1], STDERR_FILENO);
         close(pipefd[1]);
         execve(path.c_str(), NULL, NULL);
         exit(500);
     }
-    else if (pid > 0) 
+    else if (pid > 0)
     {
         close(pipefd[1]);
         int status;
         std::string output;
         char buf[1024];
         ssize_t len;
-        while ((len = read(pipefd[0], buf, sizeof(buf) - 1)) > 0) {
+        while ((len = read(pipefd[0], buf, sizeof(buf) - 1)) > 0)
+        {
             buf[len] = '\0';
             output += buf;
         }
@@ -87,7 +98,7 @@ void GetRequest::executeCgiScript(Request& req, Response& res)
         if (WIFEXITED(status))
         {
             int exitStatus = WEXITSTATUS(status);
-            if (exitStatus == 500) 
+            if (exitStatus == 500)
             {
                 res.setStatus("500 Internal Server Error");
                 res.setBody("");
@@ -102,12 +113,12 @@ void GetRequest::executeCgiScript(Request& req, Response& res)
     }
 }
 
-void GetRequest::handleGetRequest(Request& req, Response& res)
+void GetRequest::handleGetRequest(Request &req, Response &res)
 {
     if (isCgiScript(req.getUri()))
     {
         std::cout << "In GetRequest::handleGetRequest" << std::endl;
-       ExecCgi::executeCgiScript(req, res);
+        ExecCgi::executeCgiScript(req, res);
     }
     else
     {
@@ -117,7 +128,7 @@ void GetRequest::handleGetRequest(Request& req, Response& res)
         //     res.setStatus(openFile(req.getFilepath()));
         // }
         // else
-            res.setStatus(openFile(req.getUri()));
+        res.setStatus(openFile(req.getUri()));
         res.setHeaders("Content-Type: ", "text/html");
         res.setBody(getBody(res.getStatus(), req.getUri()));
         res.setHeaders("Content-Length: ", std::to_string(res.getBody().size()));

--- a/http/GetRequest.hpp
+++ b/http/GetRequest.hpp
@@ -3,18 +3,17 @@
 
 #include "Controller.hpp"
 #include "ExecCgi.hpp"
-// #include <sys/stat.h>
-
+#include <sys/stat.h>
 
 class GetRequest
 {
-    public:
-        GetRequest();
-        ~GetRequest();
-        static void handleGetRequest(Request& req, Response& res);
-        static void executeCgiScript(Request& req, Response& res);
-        static std::string openFile(const std::string& filePath);
-        static std::string getBody(const std::string& status, const std::string& filePath);
+public:
+    GetRequest();
+    ~GetRequest();
+    static void handleGetRequest(Request &req, Response &res);
+    static void executeCgiScript(Request &req, Response &res);
+    static std::string openFile(const std::string &filePath);
+    static std::string getBody(const std::string &status, const std::string &filePath);
 };
 
 #endif


### PR DESCRIPTION
# 対応したこと
## 下記のチェック処理を追加
- ファイルの存在と読み取り許可を確認
- 読み取り可能か確認

# 今後やること
- openFileの関数名変更
- openFileのreturnの型をpair<bool, string>（ファイルが開けるか、ステータスコード）に変更
- 上記変更伴う呼び出し方の変更