### PR TITLE
siege テストでのパフォーマンス向上 #72

### DIFF
--- a/http/RequestParse.cpp
+++ b/http/RequestParse.cpp
@@ -1,6 +1,9 @@
 #include "RequestParse.hpp"
 
-RequestParse::RequestParse() {}
+RequestParse::RequestParse()
+{
+    contentLength = 0;
+}
 
 RequestParse::~RequestParse() {}
 
@@ -9,14 +12,14 @@ std::vector<std::string> split(const std::string &s, char delimiter)
     std::vector<std::string> tokens;
     std::string token;
     std::istringstream tokenStream(s);
-    while (std::getline(tokenStream, token, delimiter)) 
+    while (std::getline(tokenStream, token, delimiter))
     {
         tokens.push_back(token);
     }
     return tokens;
 }
 
-void RequestParse::parseRequest(Request& request, const std::string& rawRequest)
+void RequestParse::parseRequest(Request &request, const std::string &rawRequest)
 {
     // std::cout << "IN REQUESTPARSE::PARSEREQUEST request size == " << rawRequest.size() << std::endl;
     std::istringstream requestStream(rawRequest);
@@ -27,20 +30,20 @@ void RequestParse::parseRequest(Request& request, const std::string& rawRequest)
     parseRequestLine(line, request);
     if (request.getReturnParameter().first != 0)
         return;
-    while (std::getline(requestStream, line) && line != "\r") 
-         parseHeader(line, request);
+    while (std::getline(requestStream, line) && line != "\r")
+        parseHeader(line, request);
     parseBody(requestStream, request);
 }
 
-std::string getfilepathtoURI(const std::string& uri, Request& request)
+std::string getfilepathtoURI(const std::string &uri, Request &request)
 {
-    std::string return_uri; 
+    std::string return_uri;
     std::vector<std::string> uriTokens = split(uri, '/');
     if (uriTokens.size() >= 3) // /directory/filename の場合にこの条件に入る
     {
         return_uri = "/" + uriTokens[1];
         std::string filename;
-        for(size_t i = 2; i < uriTokens.size(); i++)
+        for (size_t i = 2; i < uriTokens.size(); i++)
         {
             filename += "/" + uriTokens[i];
         }
@@ -53,29 +56,30 @@ std::string getfilepathtoURI(const std::string& uri, Request& request)
     return return_uri;
 }
 
-void RequestParse::parseRequestLine(const std::string& line, Request& request)
+void RequestParse::parseRequestLine(const std::string &line, Request &request)
 {
 
     // std::cout << "line.size() = " << line.size() << std::endl;
     if (line.size() >= 814)
-    {//return_parameter.first = 400;
+    { // return_parameter.first = 400;
         request.setReturnParameter(413, "");
         return;
     }
     // std::cout << "line = " << line << std::endl;
     std::vector<std::string> requestLineTokens = Request::split(line, ' ');
-    if (requestLineTokens.size() >= 3) 
+    if (requestLineTokens.size() >= 3)
     {
         request.setMethod(requestLineTokens[0]);
         request.setUri(getfilepathtoURI(requestLineTokens[1], request));
         request.setHttpVersion(requestLineTokens[2]);
     }
-    else 
+    else
     {
         std::cout << "REQUESTLINE ERROR" << std::endl;
         std::vector<std::string>::iterator it = requestLineTokens.begin();
-        std::cout << "----- ERROR LINE ----\n " << "size = " <<requestLineTokens.size() << std::endl;
-        for(; it != requestLineTokens.end(); it++)
+        std::cout << "----- ERROR LINE ----\n "
+                  << "size = " << requestLineTokens.size() << std::endl;
+        for (; it != requestLineTokens.end(); it++)
         {
             // std::cout << *it << std::endl;
         }
@@ -84,24 +88,24 @@ void RequestParse::parseRequestLine(const std::string& line, Request& request)
 
 // location separat filename and path
 
-void RequestParse::parseHeader(const std::string& line, Request& request)
+void RequestParse::parseHeader(const std::string &line, Request &request)
 {
     std::vector<std::string> headerTokens = split(line, ':');
-    if (headerTokens.size() >= 2) 
+    if (headerTokens.size() >= 2)
     {
         std::string key = headerTokens[0];
         std::string value = headerTokens[1];
         request.setHeaders(key, value);
-        if (key == "Host") 
+        if (key == "Host")
             request.setHost(value);
-        if (key == "Content-Length") 
+        if (key == "Content-Length")
             contentLength = std::stoi(value); // don't use stoi
     }
 }
 
-void RequestParse::parseBody(std::istringstream& requestStream, Request& request)
+void RequestParse::parseBody(std::istringstream &requestStream, Request &request)
 {
-    if (contentLength > 0) 
+    if (contentLength > 0)
     {
         std::string body;
         body.resize(this->contentLength);


### PR DESCRIPTION
速度向上
ContentLengthの初期化がされておらず、とても大きい値がセットされていたことにより、
Parse処理の中のresizeやsetBodyにかなりの時間がかかっていた。