### PR TITLE
RequestParseクラスのヘッダー解析時にポート番号をリクエストクラスに保存する #159

### DIFF
--- a/http/Request.cpp
+++ b/http/Request.cpp
@@ -258,6 +258,8 @@ const std::string &Request::getBody() { return body; }
 
 const std::string &Request::getHost() { return host; }
 
+const std::string &Request::getPort() { return port; }
+
 const std::pair<int, std::string> &Request::getReturnParameter() { return returnParameter; }
 
 const std::string &Request::getFilepath() { return filepath; }
@@ -282,6 +284,8 @@ void Request::setHttpVersion(const std::string &httpVersion) { this->httpVersion
 void Request::setHeaders(std::string key, std::string value) { headers[key] = value; }
 
 void Request::setHost(const std::string &host) { this->host = host; }
+
+void Request::setPort(const std::string &port) { this->port = port; }
 
 void Request::setBody(const std::string &body) { this->body = body; }
 

--- a/http/Request.hpp
+++ b/http/Request.hpp
@@ -30,6 +30,7 @@ public:
     // const std::map<std::string, std::string>& getQueryParameters();
     const std::string &getBody();
     const std::string &getHost();
+    const std::string &getPort();
     const std::pair<int, std::string> &getReturnParameter();
     void remakeRequest(Servers &server);
     size_t getMaxBodySize();
@@ -43,6 +44,7 @@ public:
     void setHttpVersion(const std::string &httpVersion);
     void setHeaders(std::string key, std::string value);
     void setHost(const std::string &host);
+    void setPort(const std::string &port);
     void setBody(const std::string &body);
     void setContentLength(size_t content_length);
     void setReturnParameter(int status, std::string filename);
@@ -61,6 +63,7 @@ private:
     std::map<std::string, std::string> headers;
     std::string body;
     std::string host;
+    std::string port;
     std::pair<int, std::string> returnParameter;
     std::string fileName;
     size_t max_body_size;

--- a/http/RequestParse.cpp
+++ b/http/RequestParse.cpp
@@ -97,13 +97,14 @@ void RequestParse::parseHeader(const std::string &line, Request &request)
 
         // 先頭の空白文字を削除
         size_t start = value.find_first_not_of(' ');
-        if (start != std::string::npos) {
+        if (start != std::string::npos)
             value = value.substr(start);
-        }
         request.setHeaders(key, value);
         if (key == "Host")
         {
             request.setHost(value);
+            if (headerTokens.size() >= 3)
+                request.setPort(headerTokens[2]);
         }
         if (key == "Content-Length")
         {


### PR DESCRIPTION
fix #159 